### PR TITLE
Fix `types` field name

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "sourcemap",
     "vlq"
   ],
-  "main": "dist/sourcemap-codec.umd.js",
-  "module": "dist/sourcemap-codec.mjs",
-  "typings": "dist/types/sourcemap-codec.d.ts",
+  "types": "dist/types/sourcemap-codec.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "sourcemap",
     "vlq"
   ],
+  "main": "dist/sourcemap-codec.umd.js",
+  "module": "dist/sourcemap-codec.mjs",
   "types": "dist/types/sourcemap-codec.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
`typings` is only valid in newer versions of TypeScript`. Use `types` for broader compatibility