### PR TITLE
chore: drop TextDecoder fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         latest-node-version: [16.x]
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=12"
+  },
   "exports": {
     ".": [
       {

--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -18,25 +18,7 @@ for (let i = 0; i < chars.length; i++) {
 }
 
 // Provide a fallback for older environments.
-const td =
-  typeof TextDecoder !== 'undefined'
-    ? /* #__PURE__ */ new TextDecoder()
-    : typeof Buffer !== 'undefined'
-    ? {
-        decode(buf: Uint8Array) {
-          const out = Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
-          return out.toString();
-        },
-      }
-    : {
-        decode(buf: Uint8Array) {
-          let out = '';
-          for (let i = 0; i < buf.length; i++) {
-            out += String.fromCharCode(buf[i]);
-          }
-          return out;
-        },
-      };
+const td = new TextDecoder();
 
 export function decode(mappings: string): SourceMapMappings {
   const state: [number, number, number, number, number] = new Int32Array(5) as any;


### PR DESCRIPTION
NodeJS LTS is v16
And IE is pretty much dead... 

Targeting at least NodeJS >= 11 and all green env it means that TextDecoder is available globally everywhere and you don't need any fallback solution.

reason for removing this is that some CDN/bundler have a hard time figuring out if Buffer is optional (wether or not it should polyfill it or not judging by just seeing the global `Buffer` keyword anywhere in the source)